### PR TITLE
feature: i18n対応 (日本語/英語)

### DIFF
--- a/components/FolderSelector.ts
+++ b/components/FolderSelector.ts
@@ -6,21 +6,6 @@ import {
 } from '../utils/bookmark-helpers';
 
 /**
- * UI メッセージ定数（将来のi18n対応のために構造化）
- */
-const MESSAGES = {
-  LOADING: '読み込み中...',
-  SAVE_SUCCESS: '保存しました！',
-  NO_FOLDERS: 'フォルダが見つかりませんでした。',
-  BOOKMARK_ERROR:
-    'ブックマークの読み込みに失敗しました。ページを再読み込みしてください。',
-  STORAGE_SAVE_ERROR:
-    '設定の保存に失敗しました。もう一度お試しください。',
-  FOLDER_COUNT_WARNING:
-    '注意: フォルダ数が多いため、表示に時間がかかる場合があります。',
-} as const;
-
-/**
  * FolderSelectorコンポーネントのオプション設定
  */
 export interface FolderSelectorOptions {
@@ -33,7 +18,7 @@ export interface FolderSelectorOptions {
   /** 保存処理のデバウンス時間（ミリ秒、デフォルト: 0 = デバウンスなし） */
   debounceDelay?: number;
 
-  /** 保存成功時のメッセージ（デフォルト: MESSAGES.SAVE_SUCCESS） */
+  /** 保存成功時のメッセージ（デフォルト: i18n キー 'msgSaveSuccess'） */
   successMessage?: string;
 }
 
@@ -73,7 +58,8 @@ export class FolderSelector {
       showFolderCountWarning: options?.showFolderCountWarning ?? false,
       folderCountThreshold: options?.folderCountThreshold ?? 100,
       debounceDelay: options?.debounceDelay ?? 0,
-      successMessage: options?.successMessage ?? MESSAGES.SAVE_SUCCESS,
+      successMessage: options?.successMessage ??
+        (browser.i18n.getMessage('msgSaveSuccess') || 'msgSaveSuccess'),
     };
 
     // イベントハンドラーをバインド（destroy時に削除できるように）
@@ -111,14 +97,14 @@ export class FolderSelector {
    */
   private async loadFolders(): Promise<void> {
     try {
-      this.showStatus(MESSAGES.LOADING);
+      this.showStatus(browser.i18n.getMessage('msgLoading') || 'msgLoading');
 
       // ブックマークツリーを取得
       const tree = await browser.bookmarks.getTree();
       const folders = flattenFolders(tree);
 
       if (folders.length === 0) {
-        this.showStatus(MESSAGES.NO_FOLDERS);
+        this.showStatus(browser.i18n.getMessage('msgNoFolders') || 'msgNoFolders');
         return;
       }
 
@@ -127,7 +113,7 @@ export class FolderSelector {
         this.options.showFolderCountWarning &&
         folders.length > this.options.folderCountThreshold
       ) {
-        this.showWarning(MESSAGES.FOLDER_COUNT_WARNING);
+        this.showWarning(browser.i18n.getMessage('msgFolderCountWarning') || 'msgFolderCountWarning');
       }
 
       // ドロップダウンにフォルダを追加
@@ -142,7 +128,7 @@ export class FolderSelector {
       this.showStatus(''); // ステータスをクリア
     } catch (error) {
       console.error('ブックマーク取得エラー:', error);
-      this.showStatus(MESSAGES.BOOKMARK_ERROR);
+      this.showStatus(browser.i18n.getMessage('msgBookmarkError') || 'msgBookmarkError');
     }
   }
 
@@ -205,7 +191,7 @@ export class FolderSelector {
       this.showStatus(this.options.successMessage, 2000);
     } catch (error) {
       console.error('設定保存エラー:', error);
-      this.showStatus(MESSAGES.STORAGE_SAVE_ERROR);
+      this.showStatus(browser.i18n.getMessage('msgStorageSaveError') || 'msgStorageSaveError');
     }
   }
 

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -1,8 +1,8 @@
 <!doctype html>
-<html lang="ja">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Auto Pinned Tabs 設定</title>
+    <title>Auto Pinned Tabs Settings</title>
     <style>
       body {
         width: 400px;
@@ -65,10 +65,10 @@
     </style>
   </head>
   <body>
-    <h3>起動時に開くフォルダ</h3>
-    <label for="folderSelect">フォルダを選択</label>
+    <h3>Folder to open on startup</h3>
+    <label for="folderSelect">Select a folder</label>
     <select id="folderSelect">
-      <option value="">フォルダを選択してください</option>
+      <option value="">Please select a folder</option>
     </select>
     <div id="status" class="status"></div>
     <div class="support-link">
@@ -76,7 +76,7 @@
         <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
           <path d="m8 14.25.345.666a.75.75 0 0 1-.69 0l-.008-.004-.018-.01a7.152 7.152 0 0 1-.31-.17 22.055 22.055 0 0 1-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.066 22.066 0 0 1-3.744 2.584l-.018.01-.006.003h-.002ZM4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.58 20.58 0 0 0 8 13.393a20.58 20.58 0 0 0 3.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.749.749 0 0 1-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5Z"></path>
         </svg>
-        このプロジェクトを支援する
+        <span>Support this project</span>
       </a>
     </div>
     <script type="module" src="./main.ts"></script>

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -1,7 +1,25 @@
+import { browser } from 'wxt/browser';
 import { FolderSelector } from '../../components/FolderSelector';
 
 const select = document.getElementById('folderSelect') as HTMLSelectElement;
 const status = document.getElementById('status') as HTMLDivElement;
+
+// html lang 属性をブラウザの言語設定に合わせて更新（アクセシビリティ向上）
+document.documentElement.lang = browser.i18n.getUILanguage();
+
+// 静的テキストを i18n で適用
+// DOM 構造は index.html で静的に定義されているため non-null assertion を使用
+// キー欠損時の空文字フォールバックとしてキー名自体を表示する
+document.title =
+  browser.i18n.getMessage('popupTitle') || 'popupTitle';
+(document.querySelector('h3') as HTMLHeadingElement).textContent =
+  browser.i18n.getMessage('popupHeading') || 'popupHeading';
+(document.querySelector('label[for="folderSelect"]') as HTMLLabelElement).textContent =
+  browser.i18n.getMessage('popupLabelSelect') || 'popupLabelSelect';
+(document.querySelector('#folderSelect option[value=""]') as HTMLOptionElement).textContent =
+  browser.i18n.getMessage('popupPlaceholder') || 'popupPlaceholder';
+(document.querySelector('.support-link a span') as HTMLSpanElement).textContent =
+  browser.i18n.getMessage('popupSupportLink') || 'popupSupportLink';
 
 // FolderSelectorを初期化（popup固有オプション付き）
 const folderSelector = new FolderSelector(select, status, {
@@ -11,5 +29,5 @@ const folderSelector = new FolderSelector(select, status, {
 });
 
 folderSelector.init().catch((error) => {
-  console.error('ポップアップ初期化エラー:', error);
+  console.error('Popup initialization error:', error);
 });

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1,0 +1,52 @@
+{
+  "extName": {
+    "message": "Auto Pinned Tabs"
+  },
+  "extDescription": {
+    "message": "Automatically opens bookmarked tabs as pinned tabs when Chrome starts."
+  },
+  "popupTitle": {
+    "message": "Auto Pinned Tabs Settings"
+  },
+  "popupHeading": {
+    "message": "Folder to open on startup"
+  },
+  "popupLabelSelect": {
+    "message": "Select a folder"
+  },
+  "popupPlaceholder": {
+    "message": "Please select a folder"
+  },
+  "popupSupportLink": {
+    "message": "Support this project"
+  },
+  "msgLoading": {
+    "message": "Loading..."
+  },
+  "msgSaveSuccess": {
+    "message": "Saved!"
+  },
+  "msgNoFolders": {
+    "message": "No folders found."
+  },
+  "msgBookmarkError": {
+    "message": "Failed to load bookmarks. Please reload the page."
+  },
+  "msgStorageSaveError": {
+    "message": "Failed to save settings. Please try again."
+  },
+  "msgFolderCountWarning": {
+    "message": "Warning: Many folders detected. Display may be slow."
+  },
+  "folderRoot": {
+    "message": "Root"
+  },
+  "folderUntitled": {
+    "message": "(Untitled folder: $FOLDER_ID$)",
+    "placeholders": {
+      "folder_id": {
+        "content": "$1"
+      }
+    }
+  }
+}

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -1,0 +1,52 @@
+{
+  "extName": {
+    "message": "Auto Pinned Tabs"
+  },
+  "extDescription": {
+    "message": "Chromeの起動時に、指定したブックマークフォルダのタブを自動的に固定タブとして開きます。"
+  },
+  "popupTitle": {
+    "message": "Auto Pinned Tabs 設定"
+  },
+  "popupHeading": {
+    "message": "起動時に開くフォルダ"
+  },
+  "popupLabelSelect": {
+    "message": "フォルダを選択"
+  },
+  "popupPlaceholder": {
+    "message": "フォルダを選択してください"
+  },
+  "popupSupportLink": {
+    "message": "このプロジェクトを支援する"
+  },
+  "msgLoading": {
+    "message": "読み込み中..."
+  },
+  "msgSaveSuccess": {
+    "message": "保存しました！"
+  },
+  "msgNoFolders": {
+    "message": "フォルダが見つかりませんでした。"
+  },
+  "msgBookmarkError": {
+    "message": "ブックマークの読み込みに失敗しました。ページを再読み込みしてください。"
+  },
+  "msgStorageSaveError": {
+    "message": "設定の保存に失敗しました。もう一度お試しください。"
+  },
+  "msgFolderCountWarning": {
+    "message": "注意: フォルダ数が多いため、表示に時間がかかる場合があります。"
+  },
+  "folderRoot": {
+    "message": "ルート"
+  },
+  "folderUntitled": {
+    "message": "(無題のフォルダ: $FOLDER_ID$)",
+    "placeholders": {
+      "folder_id": {
+        "content": "$1"
+      }
+    }
+  }
+}

--- a/utils/bookmark-helpers.ts
+++ b/utils/bookmark-helpers.ts
@@ -1,3 +1,5 @@
+import { browser } from 'wxt/browser';
+
 /**
  * ブックマーク関連のユーティリティ関数
  */
@@ -38,8 +40,8 @@ export function flattenFolders(
 
 /**
  * フォルダのタイトルを取得（無題の場合はフォールバック）
- * ルートフォルダ（id === '0'）は特別扱いで「ルート」と表示
- * タイトルがない場合は「(無題のフォルダ: [ID])」と表示
+ * ルートフォルダ（id === '0'）は特別扱いで i18n キー 'folderRoot' を使用
+ * タイトルがない場合は i18n キー 'folderUntitled' を使用
  * @param folder - ブックマークフォルダノード
  * @returns 表示用のタイトル
  */
@@ -47,6 +49,7 @@ export function getFolderTitle(
   folder: BookmarkTreeNode
 ): string {
   if (folder.title) return folder.title;
-  if (folder.id === '0') return 'ルート';
-  return `(無題のフォルダ: ${folder.id})`;
+  if (folder.id === '0') return browser.i18n.getMessage('folderRoot') || 'Root';
+  return browser.i18n.getMessage('folderUntitled', folder.id)
+    || `(${folder.id})`;
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -2,7 +2,9 @@ import { defineConfig } from "wxt";
 
 export default defineConfig({
   manifest: {
-    name: "Auto Pinned Tabs",
+    name: "__MSG_extName__",
+    description: "__MSG_extDescription__",
+    default_locale: "ja",
     permissions: ["bookmarks", "storage"],
     action: {
       default_popup: "popup/index.html"


### PR DESCRIPTION
## 概要

ブラウザの言語設定が英語のユーザーでも拡張機能を使いやすくするため。
これまでUIテキストが日本語ハードコードのみだったため、英語環境での利用に不便があった。
Chrome Extension標準のi18nAPIを使うことで、将来的に他言語への拡張も容易になる。

## 変更内容

- wxt.config.ts に default_locale と __MSG_*__ マニフェストキーを追加
- public/_locales/{ja,en}/messages.json を新規作成（拡張機能名・説明・UIテキスト）
- components/FolderSelector.ts のハードコードされた MESSAGES 定数を削除し、browser.i18n.getMessage() に置換
- entrypoints/popup/main.ts で静的HTMLテキストをi18nで動的に適用し、html タグの lang 属性もブラウザ言語設定に合わせて更新
- utils/bookmark-helpers.ts の getFolderTitle() をi18n対応に変更
- entrypoints/popup/index.html を英語ベースに変更（実表示はi18nが担当）

## 変更の種類

- [ ] 🐛 バグ修正 (bug fix)
- [ ] 🚀 新機能 (new feature)
- [ ] 📚 ドキュメント (documentation)
- [ ] 🔧 リファクタリング (refactoring)
- [x] 🎨 UI/UX改善 (ui/ux improvement)
- [ ] ⚡ パフォーマンス改善 (performance improvement)
- [ ] 🧪 テスト (test)
- [ ] 🔨 開発環境・ビルド (chore/build)

## テスト

<!-- どのようにテストしたか記載してください -->

- [x] ローカルでTypeScriptコンパイルが通ることを確認 (`npm run compile`)
- [x] ビルドが通ることを確認 (`npm run build`)
- [x] 実際の動作を確認した

### 動作確認の詳細

  - Chrome の言語設定を 日本語 にして動作確認 → 日本語UIが表示される
  - Chrome の言語設定を 英語 にして動作確認 → 英語UIが表示される
  - ポップアップの各UIテキスト（フォルダ選択・設定項目など）が正しく翻訳されることを確認

